### PR TITLE
Multi-sample specification extension

### DIFF
--- a/data-format/binning.mkd
+++ b/data-format/binning.mkd
@@ -1,6 +1,6 @@
 ## Binning Output Format
 
-  * Version:    0.9.1
+  * Version:    0.10.0
   * Maintainer: Peter Belmann <pbelmann@cebitec.uni-bielefeld.de>
   * Authors: CAMI challenge organizers
 
@@ -57,7 +57,7 @@ corresponding column of the output section. The following lists all defined tags
   * **BINID**
   * **TAXID**
 
-The format requires that **SEQEUNCEID** and at least one of **BINID** and **TAXID** MUST be given.
+The format requires that **SEQUENCEID** and at least one of **BINID** and **TAXID** MUST be given.
 Further optional columns can be appended to the right but MUST be 
 prefixed by a case-insensitive string with an underscore before and after the string,
 e.g. `_CUSTOM_`, to avoid collisions when this specification is extended in the future.
@@ -93,7 +93,15 @@ regular expression `[A-Za-z0-9\.;,\(\)_\-\ ]+`.
 
   * The **BINID** fields MUST be arbitrary alphanumeric identifiers for each bin.
 
-### 4. EXAMPLES
+### 4. Multi-sample format
+
+Starting with version `0.10.0`, multiple samples MAY be represented in a single file by concatenation.
+Sample entries MUST be separated by at least one empty line after the last content line of an entry
+and preceding the next header line. Additionally, a multi-sample file MUST specify the exact same
+**VERSION** tag in every entry and the exact same **TAXONOMYID** tag, if this tag is specified in at
+least one of the entries. The type and order of column tags MUST be identical for all entries.
+
+### 5. EXAMPLES
 
 There are three different scenarios for binning tools.
 
@@ -112,7 +120,7 @@ representing novel strains. In this case, you add both the **TAXID** and **BINID
 A
 ```
 #Format for Binning
-@Version:0.9.0
+@Version:0.10.0
 @SampleID:SAMPLEID
 @@SEQUENCEID	TAXID
 read1201	123
@@ -124,7 +132,7 @@ read1205	562
 B
 ```
 #Format for Binning
-@Version:0.9.0
+@Version:0.10.0
 @SampleID:SAMPLEID
 @@SEQUENCEID		BINID
 read1201	12346BIN
@@ -136,7 +144,7 @@ read1205	BIN5
 C
 ```
 #Format for Binning
-@Version:0.9.0
+@Version:0.10.0
 @SampleID:SAMPLEID
 @@SEQUENCEID	TAXID	BINID
 read1201	123	123

--- a/data-format/binning.mkd
+++ b/data-format/binning.mkd
@@ -96,13 +96,14 @@ regular expression `[A-Za-z0-9\.;,\(\)_\-\ ]+`.
 ### 4. Multi-sample format
 
 Starting with version `0.10.0`, multiple samples MAY be represented in a single file by concatenation.
-Sample entries MUST be separated by at least one empty line after the last content line of an entry
+Sample sections MUST be separated by at least one empty line after the last content line of a section
 and preceding the next header line. Additionally, a multi-sample file MUST specify the exact same
 **VERSION** tag value in every section. It MUST also specify the exact same **TAXONOMYID** tag value,
-if this tag is specified in at least one of the entries. The type and order of column tags MUST be
-identical for all sections. The **SAMPLEID** values must be unique for all concatenated sections. The
-meaning of the **BINID** values is local for each section, for instance sequences from different
-samples can only be grouped into the same bin if they are pooled and reported in a joint section.
+if this tag is specified in at least one of the sections. The type and order of column tags MUST be
+identical for all sections. The **SAMPLEID** tag values must be unique for all concatenated sections.
+The meaning of the **BINID** tag values is local for each section, for instance, `BIN1` would have a
+different meaning in each section so that sequences from different samples can only be grouped into
+the same bin if they are pooled and reported in a joint section.
 
 ### 5. EXAMPLES
 

--- a/data-format/binning.mkd
+++ b/data-format/binning.mkd
@@ -98,8 +98,11 @@ regular expression `[A-Za-z0-9\.;,\(\)_\-\ ]+`.
 Starting with version `0.10.0`, multiple samples MAY be represented in a single file by concatenation.
 Sample entries MUST be separated by at least one empty line after the last content line of an entry
 and preceding the next header line. Additionally, a multi-sample file MUST specify the exact same
-**VERSION** tag in every entry and the exact same **TAXONOMYID** tag, if this tag is specified in at
-least one of the entries. The type and order of column tags MUST be identical for all entries.
+**VERSION** tag value in every section. It MUST also specify the exact same **TAXONOMYID** tag value,
+if this tag is specified in at least one of the entries. The type and order of column tags MUST be
+identical for all sections. The **SAMPLEID** values must be unique for all concatenated sections. The
+meaning of the **BINID** values is local for each section, for instance sequences from different
+samples can only be grouped into the same bin if they are pooled and reported in a joint section.
 
 ### 5. EXAMPLES
 

--- a/data-format/binning.mkd
+++ b/data-format/binning.mkd
@@ -119,9 +119,11 @@ representing novel strains. In this case, you add both the **TAXID** and **BINID
 
 A
 ```
-#Format for Binning
+# This is the bioboxes.org binning output format at
+# https://github.com/bioboxes/rfc/tree/master/data-format
+
 @Version:0.10.0
-@SampleID:SAMPLEID
+@SampleID:mysample1
 @@SEQUENCEID	TAXID
 read1201	123
 read1202	123
@@ -131,25 +133,49 @@ read1205	562
 ```
 B
 ```
-#Format for Binning
+# This is the bioboxes.org binning output format at
+# https://github.com/bioboxes/rfc/tree/master/data-format
+
 @Version:0.10.0
-@SampleID:SAMPLEID
+@SampleID:mysample1
 @@SEQUENCEID		BINID
-read1201	12346BIN
-read1202	ANOTHERBIN
-read1203	BIN6
-read1204	BIN5
-read1205	BIN5
+contig01	12346BIN
+contig02	ANOTHERBIN
+contig03	BIN6
+contig04	BIN5
+contig05	BIN5
 ```
 C
 ```
-#Format for Binning
+# This is the bioboxes.org binning output format at
+# https://github.com/bioboxes/rfc/tree/master/data-format
+
 @Version:0.10.0
-@SampleID:SAMPLEID
+@SampleID:mysample1
 @@SEQUENCEID	TAXID	BINID
-read1201	123	123
-read1202	123	123
-read1203	131564	131564
-read1204	562	562.1
-read1205	562	562.2
+contig01	123	123
+contig02	123	123
+contig03	131564	131564
+contig04	562	562.1
+contig05	562	562.2
 ```
+D
+```
+# This is the bioboxes.org binning output format at
+# https://github.com/bioboxes/rfc/tree/master/data-format
+
+@Version:0.10.0
+@SampleID:mysample_A
+@@SEQUENCEID		BINID
+contig_A_01	BIN_A_1
+contig_A_02	BIN_A_2
+contig_A_03	BIN_A_1
+
+@Version:0.10.0
+@SampleID:mysample_B
+@@SEQUENCEID		BINID
+contig_B_01	BIN_B_1
+contig_B_02	BIN_B_1
+contig_B_03	BIN_B_2
+```
+

--- a/data-format/profiling.mkd
+++ b/data-format/profiling.mkd
@@ -143,8 +143,8 @@ or
 Starting with version `0.10.0`, multiple samples MAY be represented in a single file by concatenation.
 Sample entries MUST be separated by at least one empty line after the last content line of an entry
 and preceding the next header line. Additionally, a multi-sample file MUST specify the exact same
-**VERSION** and **RANKS** tag in every entry and the exact same **TAXONOMYID** tag, if specified in
-at least one of the entries.
+**VERSION** and **RANKS** tag in every entry and the exact same **TAXONOMYID** tag, if this tag is
+specified in at least one of the entries.
 
 ### 5. Example
 

--- a/data-format/profiling.mkd
+++ b/data-format/profiling.mkd
@@ -144,7 +144,8 @@ Starting with version `0.10.0`, multiple samples MAY be represented in a single 
 Sample entries MUST be separated by at least one empty line after the last content line of an entry
 and preceding the next header line. Additionally, a multi-sample file MUST specify the exact same
 **VERSION** and **RANKS** tag in every entry and the exact same **TAXONOMYID** tag, if this tag is
-specified in at least one of the entries.
+specified in at least one of the entries. The type and order of column tags MUST be identical for all
+entries.
 
 ### 5. Example
 

--- a/data-format/profiling.mkd
+++ b/data-format/profiling.mkd
@@ -2,7 +2,7 @@
 
   * Version:    0.9.3
   * Maintainer: Johannes Dröge <code@fungs.de>
-  * Authors:    Alice C. McHardy <alice.mchardy@helmholtz-hzi.de>,  David Koslicki <david.koslicki@math.oregonstate.edu>, Johannes Dröge <johannes.droege@uni-duesseldorf.de>, Peter Belmann <pbelmann@cebitec.uni-bielefeld.de>, Stephan Majda <stephan.majda@uni-duesseldorf.de>
+  * Authors:    Alice C. McHardy <alice.mchardy@helmholtz-hzi.de>,  David Koslicki <david.koslicki@math.oregonstate.edu>, Johannes Dröge <code@fungs.de>, Peter Belmann <pbelmann@cebitec.uni-bielefeld.de>, Stephan Majda <stephan.majda@uni-duesseldorf.de>
 
 ### 1. Outline
 

--- a/data-format/profiling.mkd
+++ b/data-format/profiling.mkd
@@ -1,10 +1,10 @@
 ## Profiling Output Format 
 
   * Version:    0.9.3
-  * Maintainer: Johannes Dröge <johannes.droege@uni-duesseldorf.de>
+  * Maintainer: Johannes Dröge <code@fungs.de>
   * Authors:    Alice C. McHardy <alice.mchardy@helmholtz-hzi.de>,  David Koslicki <david.koslicki@math.oregonstate.edu>, Johannes Dröge <johannes.droege@uni-duesseldorf.de>, Peter Belmann <pbelmann@cebitec.uni-bielefeld.de>, Stephan Majda <stephan.majda@uni-duesseldorf.de>
 
-###1. Outline
+### 1. Outline
 
 The taxonomic profiling format was originally specified for the CAMI contest
 and is intended to serve as a standard format for the output of
@@ -22,7 +22,7 @@ Files containing this data format should be named with the filename suffix `.pro
 
 Regular expressions, when provided, are given as specified in IEEE Std 1003.1™ ERE.
 
-###2. Header section
+### 2. Header section
 
 Each header line MUST begin with the character `@`. A single `@` defines a
 key-value pair in the format **TAG:VALUE** where **TAG** MUST be an
@@ -139,7 +139,7 @@ or
     2157|651137|651142|1104572|1052838
 
 
-###4. Example
+### 4. Example
 
     # Taxonomic Profiling Output
     @SampleID:SAMPLEID

--- a/data-format/profiling.mkd
+++ b/data-format/profiling.mkd
@@ -141,11 +141,11 @@ or
 ### 4. Multi-sample format
 
 Starting with version `0.10.0`, multiple samples MAY be represented in a single file by concatenation.
-Sample entries MUST be separated by at least one empty line after the last content line of an entry
+Sample sections MUST be separated by at least one empty line after the last content line of a section
 and preceding the next header line. Additionally, a multi-sample file MUST specify the exact same
-**VERSION** and **RANKS** tag in every entry and the exact same **TAXONOMYID** tag, if this tag is
-specified in at least one of the entries. The type and order of column tags MUST be identical for all
-entries.
+**VERSION** and **RANKS** tag values in every section and the exact same **TAXONOMYID** tag value, if
+this tag is specified in at least one of the sections. The type and order of column tags MUST be
+identical for all sections. The **SAMPLEID** tag values must be unique for all concatenated sections.
 
 ### 5. Example
 

--- a/data-format/profiling.mkd
+++ b/data-format/profiling.mkd
@@ -140,19 +140,21 @@ or
 
 ### 4. Multi-sample format
 
-Starting with version 0.10.0, multiple samples MAY be represented in a single file by concatenation.
+Starting with version `0.10.0`, multiple samples MAY be represented in a single file by concatenation.
 Sample entries MUST be separated by at least one empty line after the last content line of an entry
-and in front of the next header line. Additionally, a multi-sample file MUST specify the exact same
+and preceding the next header line. Additionally, a multi-sample file MUST specify the exact same
 **VERSION** and **RANKS** tag in every entry and the exact same **TAXONOMYID** tag, if specified in
 at least one of the entries.
 
 ### 5. Example
 
-    # Taxonomic Profiling Output
-    @SampleID:SAMPLEID
-    @Version:0.9.1
+    # This is the bioboxes.org profiling output format at
+    # https://github.com/bioboxes/rfc/tree/master/data-format
+    
+    @SampleID:mysample1
+    @Version:0.10.0
     @Ranks:superkingdom|phylum|class|order|family|genus|species
-    @TaxonomyID:ncbi-taxonomy_DATE
+    @TaxonomyID:ncbi-taxonomy_20171004
     @@TAXID	RANK	TAXPATH	TAXPATHSN	PERCENTAGE
     2	superkingdom	2	Bacteria	98.81211
     2157	superkingdom	2157	Archaea	1.18789

--- a/data-format/profiling.mkd
+++ b/data-format/profiling.mkd
@@ -1,6 +1,6 @@
 ## Profiling Output Format 
 
-  * Version:    0.9.3
+  * Version:    0.10.0
   * Maintainer: Johannes Dröge <code@fungs.de>
   * Authors:    Alice C. McHardy <alice.mchardy@helmholtz-hzi.de>,  David Koslicki <david.koslicki@math.oregonstate.edu>, Johannes Dröge <code@fungs.de>, Peter Belmann <pbelmann@cebitec.uni-bielefeld.de>, Stephan Majda <stephan.majda@uni-duesseldorf.de>
 
@@ -138,8 +138,15 @@ or
     # Example for TAXPATH:
     2157|651137|651142|1104572|1052838
 
+### 4. Multi-sample format
 
-### 4. Example
+Starting with version 0.10.0, multiple samples MAY be represented in a single file by concatenation.
+Sample entries MUST be separated by at least one empty line after the last content line of an entry
+and in front of the next header line. Additionally, a multi-sample file MUST specify the exact same
+**VERSION** and **RANKS** tag in every entry and the exact same **TAXONOMYID** tag, if specified in
+at least one of the entries.
+
+### 5. Example
 
     # Taxonomic Profiling Output
     @SampleID:SAMPLEID


### PR DESCRIPTION
As requested by @alicemchardy and some CAMI users, I have extended the specs to allow for simple file concatenation. This is a backwards-incompatible change, which means that we have new major versions of the two specs. The specs impose restrictions on the concatenated content (same taxonomy version, column layout and unambiguous sample ids) which could be loosened in upcoming minor version bumps, if reasonable. The restrictions make parsing and interpretation easier.